### PR TITLE
Fixed preg_replace not removing apostrophes

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -62,7 +62,7 @@ class Generator
             foreach($order as $element) {
                 switch ($element) {
                     case "word":
-                        $password .= preg_replace('/(?<=\w) .*/', "", $this->faker->streetName);
+                        $password .= preg_replace('/(\W)+/', "", $this->faker->streetName);
                         break;
                     case "num":
                         $password .= $this->faker->randomNumber(3);

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -62,7 +62,7 @@ class Generator
             foreach($order as $element) {
                 switch ($element) {
                     case "word":
-                        $password .= preg_replace('/(\W)+/', "", $this->faker->streetName);
+                        $password .= preg_replace('/(\W)+.*/', "", $this->faker->streetName);
                         break;
                     case "num":
                         $password .= $this->faker->randomNumber(3);


### PR DESCRIPTION
The regex used to remove unwanted characters for the "word" string was allowing apostrophes in some names. This has now been simplified to remove any non-word character.
